### PR TITLE
Add personal GitHub Pages site and shared theme

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="20" fill="#0070f3"/>
+  <text x="50" y="60" font-size="60" text-anchor="middle" fill="white">M</text>
+</svg>

--- a/hauswerk-plugins/index.html
+++ b/hauswerk-plugins/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hauswerk Plugins</title>
+  <link rel="icon" href="/favicon.svg">
+  <link rel="stylesheet" href="/theme.css">
+</head>
+<body>
+  <header>
+    <h1>Hauswerk Plugins</h1>
+    <nav>
+      <a href="/">Home</a>
+      <a href="https://michligtenberg2.github.io/hauswerk-plugins">Hauswerk Plugins</a>
+      <a href="https://michligtenberg2.github.io/zwoffietracker">Zwoffietracker</a>
+      <a href="https://michligtenberg2.github.io/tonybot">TonyBot</a>
+      <button id="theme-toggle" class="toggle">🌓</button>
+    </nav>
+  </header>
+  <main>
+    <p>Voorbeeldproject dat de gedeelde <code>theme.css</code> gebruikt.</p>
+  </main>
+  <footer>&copy; 2024 M. Ligtenberg</footer>
+  <script src="/script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>M. Ligtenberg – Art, Code, Chaos</title>
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="stylesheet" href="theme.css">
+</head>
+<body>
+  <header>
+    <h1>M. Ligtenberg</h1>
+    <nav>
+      <a href="/">Home</a>
+      <a href="https://michligtenberg2.github.io/hauswerk-plugins">Hauswerk Plugins</a>
+      <a href="https://michligtenberg2.github.io/zwoffietracker">Zwoffietracker</a>
+      <a href="https://michligtenberg2.github.io/tonybot">TonyBot</a>
+      <button id="theme-toggle" class="toggle">🌓</button>
+    </nav>
+  </header>
+  <main>
+    <p>M. Ligtenberg, 22 jaar, multidisciplinair maker – van tools tot kunst, van geluid tot systeemkritiek.</p>
+    <section id="repo-list">
+      <!-- Repositories met GitHub Pages verschijnen hier -->
+    </section>
+  </main>
+  <footer>&copy; 2024 M. Ligtenberg</footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/layout.html
+++ b/layout.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{title}}</title>
+  <link rel="icon" href="/favicon.svg">
+  <link rel="stylesheet" href="/theme.css">
+</head>
+<body>
+  <header>
+    <h1>{{heading}}</h1>
+    <nav>
+      <a href="/">Home</a>
+      <a href="https://michligtenberg2.github.io/hauswerk-plugins">Hauswerk Plugins</a>
+      <a href="https://michligtenberg2.github.io/zwoffietracker">Zwoffietracker</a>
+      <a href="https://michligtenberg2.github.io/tonybot">TonyBot</a>
+      <button id="theme-toggle" class="toggle">🌓</button>
+    </nav>
+  </header>
+  <main>
+    {{content}}
+  </main>
+  <footer>&copy; 2024 M. Ligtenberg</footer>
+  <script src="/script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,30 @@
+function toggleDarkMode() {
+  document.body.classList.toggle('dark');
+  localStorage.setItem('theme', document.body.classList.contains('dark') ? 'dark' : 'light');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (localStorage.getItem('theme') === 'dark') {
+    document.body.classList.add('dark');
+  }
+  const toggleBtn = document.getElementById('theme-toggle');
+  if (toggleBtn) toggleBtn.addEventListener('click', toggleDarkMode);
+
+  const list = document.getElementById('repo-list');
+  if (list) {
+    fetch('https://api.github.com/users/michligtenberg2/repos')
+      .then(r => r.json())
+      .then(data => {
+        data.filter(repo => repo.has_pages && repo.name !== 'michligtenberg2.github.io')
+          .forEach(repo => {
+            const a = document.createElement('a');
+            a.href = `https://michligtenberg2.github.io/${repo.name}`;
+            a.textContent = repo.name;
+            const div = document.createElement('div');
+            div.className = 'repo';
+            div.appendChild(a);
+            list.appendChild(div);
+          });
+      });
+  }
+});

--- a/theme.css
+++ b/theme.css
@@ -1,0 +1,63 @@
+:root {
+  --background: #f5f5f7;
+  --foreground: #1d1d1f;
+  --accent: #0070f3;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+    'Open Sans', 'Helvetica Neue', sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: inherit;
+  line-height: 1.6;
+}
+
+header {
+  padding: 1rem;
+}
+
+nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+nav a {
+  color: var(--foreground);
+  text-decoration: none;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  transition: background 0.2s;
+}
+
+nav a:hover {
+  background: rgba(0,0,0,0.05);
+}
+
+main {
+  padding: 1rem;
+}
+
+footer {
+  padding: 1rem;
+  text-align: center;
+}
+
+button.toggle {
+  margin-left: auto;
+  cursor: pointer;
+  background: none;
+  border: 1px solid var(--foreground);
+  color: var(--foreground);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+}
+
+.dark {
+  --background: #1d1d1f;
+  --foreground: #f5f5f7;
+  --accent: #0ea5ff;
+}


### PR DESCRIPTION
## Summary
- set up minimal personal homepage in `index.html`
- style via `theme.css` and toggle dark mode with `script.js`
- show layout template for reuse
- include example subproject `hauswerk-plugins`

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6879d8656a8c8322aeac82de29f38947